### PR TITLE
Dockerfiles for CI and a skeleton of the test suite - release-0.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
 # This file is needed by kubebuilder but all functionality should exist inside
 # the hack/ files.
 
+CGO_ENABLED=0
+GOOS=linux
+CORE_IMAGES=./cmd/gcppubsub_receive_adapter ./cmd/githubsource ./cmd/heartbeats \
+            ./cmd/heartbeats_receiver ./cmd/kuberneteseventsource ./cmd/manager \
+            ./cmd/message_dumper
+
 all: generate manifests test verify
 	
 # Run tests
@@ -33,3 +39,18 @@ verify-codegen:
 # Verify manifests
 verify-manifests:
 	./hack/verify-manifests.sh
+
+# Install core images
+install:
+	go install $(CORE_IMAGES)
+.PHONY: install
+
+# Run E2E tests on OpenShift
+test-e2e:
+	./openshift/e2e-tests-openshift.sh
+.PHONY: test-e2e
+
+# Generate Dockerfiles for images used by ci-operator. The files need to be committed manually.
+generate-dockerfiles:
+	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/knative-images $(CORE_IMAGES)
+.PHONY: generate-dockerfiles

--- a/openshift/ci-operator/Dockerfile.in
+++ b/openshift/ci-operator/Dockerfile.in
@@ -1,0 +1,5 @@
+# Do not edit! This file was generate via Makefile
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+
+ADD ${bin} /usr/bin/${bin}
+ENTRYPOINT ["/usr/bin/${bin}"]

--- a/openshift/ci-operator/generate-dockerfiles.sh
+++ b/openshift/ci-operator/generate-dockerfiles.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -x
+
+function generate_dockefiles() {
+  local target_dir=$1; shift
+  for img in $@; do
+    local image_base=$(basename $img)
+    mkdir -p $target_dir/$image_base
+    bin=$image_base envsubst < openshift/ci-operator/Dockerfile.in > $target_dir/$image_base/Dockerfile
+  done
+}
+
+generate_dockefiles $@

--- a/openshift/ci-operator/knative-images/gcppubsub_receive_adapter/Dockerfile
+++ b/openshift/ci-operator/knative-images/gcppubsub_receive_adapter/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generate via Makefile
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+
+ADD gcppubsub_receive_adapter /usr/bin/gcppubsub_receive_adapter
+ENTRYPOINT ["/usr/bin/gcppubsub_receive_adapter"]

--- a/openshift/ci-operator/knative-images/githubsource/Dockerfile
+++ b/openshift/ci-operator/knative-images/githubsource/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generate via Makefile
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+
+ADD githubsource /usr/bin/githubsource
+ENTRYPOINT ["/usr/bin/githubsource"]

--- a/openshift/ci-operator/knative-images/heartbeats/Dockerfile
+++ b/openshift/ci-operator/knative-images/heartbeats/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generate via Makefile
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+
+ADD heartbeats /usr/bin/heartbeats
+ENTRYPOINT ["/usr/bin/heartbeats"]

--- a/openshift/ci-operator/knative-images/heartbeats_receiver/Dockerfile
+++ b/openshift/ci-operator/knative-images/heartbeats_receiver/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generate via Makefile
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+
+ADD heartbeats_receiver /usr/bin/heartbeats_receiver
+ENTRYPOINT ["/usr/bin/heartbeats_receiver"]

--- a/openshift/ci-operator/knative-images/kuberneteseventsource/Dockerfile
+++ b/openshift/ci-operator/knative-images/kuberneteseventsource/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generate via Makefile
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+
+ADD kuberneteseventsource /usr/bin/kuberneteseventsource
+ENTRYPOINT ["/usr/bin/kuberneteseventsource"]

--- a/openshift/ci-operator/knative-images/manager/Dockerfile
+++ b/openshift/ci-operator/knative-images/manager/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generate via Makefile
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+
+ADD manager /usr/bin/manager
+ENTRYPOINT ["/usr/bin/manager"]

--- a/openshift/ci-operator/knative-images/message_dumper/Dockerfile
+++ b/openshift/ci-operator/knative-images/message_dumper/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generate via Makefile
+FROM registry.svc.ci.openshift.org/openshift/origin-v3.11:base
+
+ADD message_dumper /usr/bin/message_dumper
+ENTRYPOINT ["/usr/bin/message_dumper"]

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -1,0 +1,18 @@
+#!/bin/sh 
+
+source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
+
+set -x
+
+function run_e2e_tests(){
+  header "Running tests"
+  echo "The E2E test suite is currently empty"
+}
+
+failed=0
+
+run_e2e_tests || failed=1
+
+(( failed )) && exit 1
+
+success


### PR DESCRIPTION
Depends on https://github.com/openshift/release/pull/2600 and https://github.com/openshift/knative-eventing-sources/pull/3
When the other two PRs are integrated please call the Prow retest command to see if the CI runs (or possibly re-open this PR if retest doesn't work.