### PR TITLE
Back porting upstream PR 357

### DIFF
--- a/config/201-clusterrole.yaml
+++ b/config/201-clusterrole.yaml
@@ -35,7 +35,18 @@ rules:
   - patch
   - delete
 
-# Source statuses update
+# Sources finalizer
+- apiGroups:
+  - sources.eventing.knative.dev
+  resources:
+  - awssqssources/finalizers
+  - containersources/finalizers
+  - cronjobsources/finalizers
+  - githubsources/finalizers
+  - kuberneteseventsources/finalizers
+  verbs: *everything
+
+  # Source statuses update
 - apiGroups:
   - sources.eventing.knative.dev
   resources:

--- a/openshift/release/knative-eventing-sources-v0.5.0.yaml
+++ b/openshift/release/knative-eventing-sources-v0.5.0.yaml
@@ -34,6 +34,15 @@ rules:
 - apiGroups:
   - sources.eventing.knative.dev
   resources:
+  - awssqssources/finalizers
+  - containersources/finalizers
+  - cronjobsources/finalizers
+  - githubsources/finalizers
+  - kuberneteseventsources/finalizers
+  verbs: *everything
+- apiGroups:
+  - sources.eventing.knative.dev
+  resources:
   - awssqssources/status
   - containersources/status
   - cronjobsources/status


### PR DESCRIPTION
Backporting upstream 357 PR to our 0.5.0 release branch, which caused SRVKE-70 (on 0.4.1) 