### PR TITLE
More memory: matching latest upstream

### DIFF
--- a/config/500-controller.yaml
+++ b/config/500-controller.yaml
@@ -40,10 +40,10 @@ spec:
         - name: CRONJOB_RA_IMAGE
           value: github.com/knative/eventing-sources/cmd/cronjob_receive_adapter
         resources:
-          limits:
-            cpu: 100m
-            memory: 30Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 1000Mi
+          limits:
+            cpu: 1000m
+            memory: 1000Mi
       terminationGracePeriodSeconds: 10

--- a/openshift/release/knative-eventing-sources-v0.5.0.yaml
+++ b/openshift/release/knative-eventing-sources-v0.5.0.yaml
@@ -537,12 +537,12 @@ spec:
         - name: CRONJOB_RA_IMAGE
           value: quay.io/openshift-knative/knative-eventing-sources-cronjob-receive-adapter:v0.5.0
         resources:
-          limits:
-            cpu: 100m
-            memory: 30Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 1000Mi
+          limits:
+            cpu: 1000m
+            memory: 1000Mi
       terminationGracePeriodSeconds: 10
 ---
 apiVersion: v1


### PR DESCRIPTION
On upstream the "source controller" will be part of the "eventing" repo (since moving some sources to "eventing" core), starting with 0.6.0 upstream.

However there (in core) it has higher settings:
https://github.com/knative/eventing/blob/master/config/500-sources-controller.yaml#L42-L47

on `-sources` repo they are still lower:
https://github.com/knative/eventing-sources/blob/master/config/500-controller.yaml#L41-L46

This same PR was proposed to the "eventing-sources" repo (see PR 381 there)