### PR TITLE
Updating the location of the relocated Kafka Source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,8 @@ verify-manifests:
 # Install core images
 install:
 	go install $(CORE_IMAGES)
-	go build -o $(GOPATH)/bin/kafka-source-controller ./contrib/kafka/cmd/controller
-	go build -o $(GOPATH)/bin/kafka-source-adapter ./contrib/kafka/cmd/receive_adapter
+	go build -o $(GOPATH)/bin/kafka-source-controller ./kafka/source/cmd/controller
+	go build -o $(GOPATH)/bin/kafka-source-adapter ./kafka/source/cmd/receive_adapter
 	go build -o $(GOPATH)/bin/camel-source-controller ./contrib/camel/cmd/controller
 source.adapter: install
 

--- a/openshift/release/resolve.sh
+++ b/openshift/release/resolve.sh
@@ -20,8 +20,8 @@ function resolve_resources(){
     # 4. Remove empty lines
     sed -e "s+\(.* image: \)\(github.com\)\(.*/\)\(test/\)\(.*\)+\1\2 \3\4test-\5+g" \
         -e "s+github.com/knative/eventing-sources/contrib/camel/cmd/controller+${image_prefix}camel-source-controller${image_tag}+" \
-        -e "s+github.com/knative/eventing-sources/contrib/kafka/cmd/receive_adapter+${image_prefix}kafka-source-adapter${image_tag}+" \
-        -e "s+github.com/knative/eventing-sources/contrib/kafka/cmd/controller+${image_prefix}kafka-source-controller${image_tag}+" \
+        -e "s+github.com/knative/eventing-sources/kafka/source/cmd/receive_adapter+${image_prefix}kafka-source-adapter${image_tag}+" \
+        -e "s+github.com/knative/eventing-sources/kafka/source/cmd/controller+${image_prefix}kafka-source-controller${image_tag}+" \
         -e "s+github.com/knative/eventing-sources/cmd/github_receive_adapter+${image_prefix}github-receive-adapter${image_tag}+" \
         -e "s+\(.* image: \)\(github.com\)\(.*/\)\(.*\)+\1${image_prefix}\4${image_tag}+g" \
         -e "s+\(.* value: \)\(github.com\)\(.*/\)\(.*\)+\1${image_prefix}\4${image_tag}+g" \


### PR DESCRIPTION
@lberk  this is unrelated to the build failures, reported on slack  (the report there is about the kafka-channel-crd...)

this basically refflects the new location of the KafkaSources, due to:
https://github.com/knative/eventing-contrib/pull/426